### PR TITLE
make createClickeableText also hoverable, and fixing hoverbox

### DIFF
--- a/src/main/java/dev/_2lstudios/advancedparties/utils/ComponentUtils.java
+++ b/src/main/java/dev/_2lstudios/advancedparties/utils/ComponentUtils.java
@@ -1,15 +1,16 @@
 package dev._2lstudios.advancedparties.utils;
 
-import lib__net.md_5.bungee.api.chat.BaseComponent;
-import lib__net.md_5.bungee.api.chat.ClickEvent;
-import lib__net.md_5.bungee.api.chat.ComponentBuilder;
-import lib__net.md_5.bungee.api.chat.TextComponent;
+import lib__net.md_5.bungee.api.chat.*;
 
 public class ComponentUtils {
     public static BaseComponent[] createClickeableText(String text, String command) {
-        return new ComponentBuilder(TextComponent.fromLegacyText(text))
-            .event(
-                new ClickEvent(ClickEvent.Action.RUN_COMMAND, command)
-            ).create();
+        return new ComponentBuilder()
+          .append(text)
+          .event(
+            new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText(text))
+          )
+          .event(
+            new ClickEvent(ClickEvent.Action.RUN_COMMAND, command)
+          ).create();
     }
 }


### PR DESCRIPTION
The origin one got wired hover box, user aften click "accept" but got no response, it's because the area that "do actual trigger the event" not matching the text itself.

This PR fixes the problem by using `append(String)` instead of `append(TextComponent.fromLegacyText)`, also adds hover  for them, makes UX better.